### PR TITLE
rlimit fixes

### DIFF
--- a/Betree/BetreeInv.i.dfy
+++ b/Betree/BetreeInv.i.dfy
@@ -377,7 +377,7 @@ module BetreeInv {
     }
   }
 
-  lemma RedirectPreservesAcyclic(s: Variables, s': Variables, redirect: Redirect)
+  lemma {:timeLimitMultiplier 2} RedirectPreservesAcyclic(s: Variables, s': Variables, redirect: Redirect)
     requires Inv(s);
     requires Redirect(s.bcv, s'.bcv, redirect);
     ensures Acyclic(s');

--- a/Betree/BlockInterface.i.dfy
+++ b/Betree/BlockInterface.i.dfy
@@ -206,7 +206,7 @@ abstract module BlockInterface refines Transactable {
     }
   }
 
-  lemma TransactionPreservesInv(s: Variables, s': Variables, ops: seq<Op>)
+  lemma {:timeLimitMultiplier 2} TransactionPreservesInv(s: Variables, s': Variables, ops: seq<Op>)
     requires Inv(s)
     requires Transaction(s, s', ops)
     ensures Inv(s')

--- a/BlockCacheSystem/BetreeCache.i.dfy
+++ b/BlockCacheSystem/BetreeCache.i.dfy
@@ -82,7 +82,7 @@ module BetreeCache refines BlockMachine {
     BC.InitImpliesInv(s);
   }
 
-  lemma BetreeMoveStepPreservesInv(s: Variables, s': Variables, dop: D.DiskOp, vop: VOp, betreeStep: BetreeStep)
+  lemma {:timeLimitMultiplier 3} BetreeMoveStepPreservesInv(s: Variables, s': Variables, dop: D.DiskOp, vop: VOp, betreeStep: BetreeStep)
   requires Inv(s)
   requires BetreeMove(s, s', dop, vop, betreeStep)
   ensures Inv(s')

--- a/BlockCacheSystem/BetreeSystem.i.dfy
+++ b/BlockCacheSystem/BetreeSystem.i.dfy
@@ -146,7 +146,7 @@ module BetreeSystem {
     BT.NextPreservesInv(EphemeralBetree(s).value, EphemeralBetree(s').value, vop.uiop);
   }
 
-  lemma BlockCacheMoveStepPreservesInv(s: Variables, s': Variables, dop: D.DiskOp, vop: VOp, step: BC.Step)
+  lemma {:timeLimitMultiplier 2} BlockCacheMoveStepPreservesInv(s: Variables, s': Variables, dop: D.DiskOp, vop: VOp, step: BC.Step)
     requires Inv(s)
     requires !step.TransactionStep?
     requires M.BlockCacheMove(s.machine, s'.machine, dop, vop, step)

--- a/BlockCacheSystem/BetreeSystem_Refines_StatesViewPivotBetree.i.dfy
+++ b/BlockCacheSystem/BetreeSystem_Refines_StatesViewPivotBetree.i.dfy
@@ -72,7 +72,7 @@ module BetreeSystem_Refines_StatesViewPivotBetree {
     assert View.NextStep(I(s), I(s'), vop, View.AdvanceStep);
   }
 
-  lemma BlockCacheMoveStepRefines(s: System.Variables, s': System.Variables, dop: D.DiskOp, vop: VOp, step: BC.Step)
+  lemma {:timeLimitMultiplier 3} BlockCacheMoveStepRefines(s: System.Variables, s': System.Variables, dop: D.DiskOp, vop: VOp, step: BC.Step)
     requires System.Inv(s)
     requires !step.TransactionStep?
     requires M.BlockCacheMove(s.machine, s'.machine, dop, vop, step)

--- a/Impl/BucketGeneratorModel.i.dfy
+++ b/Impl/BucketGeneratorModel.i.dfy
@@ -247,7 +247,7 @@ module BucketGeneratorModel {
       None
   }
 
-  lemma GenLeftIsMinimum(g: Generator)
+  lemma {:timeLimitMultiplier 3} GenLeftIsMinimum(g: Generator)
   requires WM(g)
   requires WF(g)
   requires Monotonic(g)
@@ -276,7 +276,7 @@ module BucketGeneratorModel {
     }
   }
 
-  lemma GenPopIsRemove(g: Generator)
+  lemma {:timeLimitMultiplier 3} GenPopIsRemove(g: Generator)
   requires WM(g)
   requires WF(g)
   requires Monotonic(g)
@@ -347,7 +347,7 @@ module BucketGeneratorModel {
     }
   }
 
-  lemma GenComposeIsMonotonic(top: Generator, bot: Generator)
+  lemma {:timeLimitMultiplier 3} GenComposeIsMonotonic(top: Generator, bot: Generator)
   requires WF(top)
   requires WF(bot)
   requires WM(top)
@@ -374,7 +374,7 @@ module BucketGeneratorModel {
     }
   }
 
-  lemma GenComposeIsCompose(top: Generator, bot: Generator)
+  lemma {:timeLimitMultiplier 3} GenComposeIsCompose(top: Generator, bot: Generator)
   requires WF(top)
   requires WF(bot)
   requires WM(top)
@@ -426,7 +426,7 @@ module BucketGeneratorModel {
     }*/
   }
 
-  lemma GenFromBucketWithLowerBoundYieldsClampStart(bucket: Bucket, start: UI.RangeStart)
+  lemma {:timeLimitMultiplier 3} GenFromBucketWithLowerBoundYieldsClampStart(bucket: Bucket, start: UI.RangeStart)
   requires WFBucket(bucket)
   requires BucketWellMarshalled(bucket)
   ensures var g := GenFromBucketWithLowerBound(bucket, start);
@@ -460,7 +460,8 @@ module BucketGeneratorModel {
     }
   }
 
-  lemma {:induction true} GenFromBucketStackWithLowerBoundYieldsComposeSeq(buckets: seq<Bucket>, start: UI.RangeStart)
+  lemma {:induction true} {:timeLimitMultiplier 3}
+    GenFromBucketStackWithLowerBoundYieldsComposeSeq(buckets: seq<Bucket>, start: UI.RangeStart)
   requires |buckets| >= 1
   requires forall i | 0 <= i < |buckets| :: WFBucket(buckets[i])
   requires BucketListWellMarshalled(buckets)

--- a/Impl/BucketSuccessorLoopModel.i.dfy
+++ b/Impl/BucketSuccessorLoopModel.i.dfy
@@ -93,7 +93,7 @@ module BucketSuccessorLoopModel {
       None
   }
 
-  lemma ProcessGeneratorResult(
+  lemma {:timeLimitMultiplier 3} ProcessGeneratorResult(
       bucket: BucketMap,
       left: BucketMap,
       right: BucketMap,
@@ -194,7 +194,7 @@ module BucketSuccessorLoopModel {
     assert end.EExclusive? ==> Keyspace.lt(key, end.key);
   }
 
-  lemma GetSuccessorInBucketStackResult(
+  lemma {:timeLimitMultiplier 3} GetSuccessorInBucketStackResult(
       buckets: seq<Bucket>,
       maxToFind: int,
       start: UI.RangeStart,

--- a/Impl/FlushImpl.i.dfy
+++ b/Impl/FlushImpl.i.dfy
@@ -33,7 +33,7 @@ module FlushImpl {
 
   import IT = IndirectionTable
 
-  method doFlush(linear inout s: ImplVariables, parentref: BT.G.Reference, slot: uint64, childref: BT.G.Reference)
+  method {:timeLimitMultiplier 2} doFlush(linear inout s: ImplVariables, parentref: BT.G.Reference, slot: uint64, childref: BT.G.Reference)
   requires old_s.Inv()
   requires old_s.Ready?
   requires old_s.cache.ptr(childref).Some?
@@ -102,7 +102,7 @@ module FlushImpl {
     }
   }
   
-  method flush(linear inout s: ImplVariables, parentref: BT.G.Reference, slot: uint64, childref: BT.G.Reference)
+  method {:timeLimitMultiplier 2} flush(linear inout s: ImplVariables, parentref: BT.G.Reference, slot: uint64, childref: BT.G.Reference)
   requires old_s.Inv()
   requires old_s.Ready?
   requires old_s.cache.ptr(childref).Some?

--- a/Impl/FlushModel.i.dfy
+++ b/Impl/FlushModel.i.dfy
@@ -83,7 +83,7 @@ module FlushModel {
     )
   }
 
-  lemma flushCorrect(s: BBC.Variables, parentref: BT.G.Reference, slot: int, childref: BT.G.Reference, child: Node, refUpperBound: uint64)
+  lemma {:timeLimitMultiplier 3} flushCorrect(s: BBC.Variables, parentref: BT.G.Reference, slot: int, childref: BT.G.Reference, child: Node, refUpperBound: uint64)
   requires flush.requires(s, parentref, slot, childref, child, refUpperBound)
   requires s.totalCacheSize() <= MaxCacheSize() - 1
   ensures var s' := flush(s, parentref, slot, childref, child, refUpperBound);

--- a/Impl/GrowModel.i.dfy
+++ b/Impl/GrowModel.i.dfy
@@ -60,7 +60,7 @@ module GrowModel {
     )
   }
 
-  lemma growCorrect(s: BBC.Variables, refUpperBound: uint64)
+  lemma {:timeLimitMultiplier 3} growCorrect(s: BBC.Variables, refUpperBound: uint64)
   requires grow.requires(s, refUpperBound)
   requires s.totalCacheSize() <= MaxCacheSize() - 1
   ensures var s' := grow(s, refUpperBound);

--- a/Impl/IOImpl.i.dfy
+++ b/Impl/IOImpl.i.dfy
@@ -247,10 +247,8 @@ module IOImpl {
   method PageInNodeReq(linear inout s: ImplVariables, io: DiskIOHandler, ref: BC.Reference)
   requires io.initialized();
   requires old_s.Ready?
-  // requires old_s.WFBCVars()
   requires ref in old_s.ephemeralIndirectionTable.I().locs
 
-  // [yizhou7]: addtional preconditions
   requires old_s.Inv()
   requires ref !in old_s.cache.I()
   requires old_s.TotalCacheSize() as int <= MaxCacheSize() - 1
@@ -336,7 +334,6 @@ module IOImpl {
   requires io.diskOp().RespReadOp?
   requires old_s.Loading?
 
-  // [yizhou7]: addtional preconditions
   requires old_s.Inv()
   requires ValidDiskOp(diskOp(IIO(io)))
   requires ValidIndirectionTableLocation(LocOfRespRead(diskOp(IIO(io)).respRead))
@@ -419,13 +416,11 @@ module IOImpl {
     }
   }
 
-  // [yizhou7][fixme]: this takes a long time to go through
-  method PageInNodeResp(linear inout s: ImplVariables, io: DiskIOHandler)
+  method {:timeLimitMultiplier 2} PageInNodeResp(linear inout s: ImplVariables, io: DiskIOHandler)
   requires old_s.WFBCVars()
   requires io.diskOp().RespReadOp?
   requires old_s.Ready?
 
-  // [yizhou7]: addtional preconditions
   requires old_s.Inv()
   requires ValidDiskOp(diskOp(IIO(io)))
 
@@ -576,7 +571,6 @@ module IOImpl {
   requires old_s.Ready?
   requires old_s.frozenIndirectionTableLoc.Some?
 
-  // [yizhou7]: addtional preconditions
   requires old_s.outstandingIndirectionTableWrite == Some(IIO(io).id)
   requires ValidIndirectionTableLocation(LocOfRespWrite(diskOp(IIO(io)).respWrite))
   ensures && s.WFBCVars()

--- a/Impl/IndirectionTable.i.dfy
+++ b/Impl/IndirectionTable.i.dfy
@@ -935,7 +935,7 @@ module IndirectionTable {
       }
     }
 
-    linear inout method UpdateAndRemoveLoc(ref: BT.G.Reference, succs: seq<BT.G.Reference>)
+    linear inout method {:timeLimitMultiplier 2} UpdateAndRemoveLoc(ref: BT.G.Reference, succs: seq<BT.G.Reference>)
     returns (oldLoc : Option<Location>)
     requires old_self.Inv()
     requires old_self.TrackingGarbage()
@@ -1307,7 +1307,7 @@ module IndirectionTable {
           == PredecessorSetRestrictedPartial(graph, dest, domain, next, j);
     }
 
-    static method ComputeRefCountsInnerLoop(linear inout tbl': HashMap, shared tbl: HashMap, it: LinearMutableMap.Iterator<Entry>)
+    static method {:timeLimitMultiplier 2} ComputeRefCountsInnerLoop(linear inout tbl': HashMap, shared tbl: HashMap, it: LinearMutableMap.Iterator<Entry>)
     returns (success: bool, it': LinearMutableMap.Iterator<Entry>)
     requires it.next.Next?
     requires ComputeRefCountsOuterLoopInv(old_tbl', tbl, it)
@@ -1610,7 +1610,7 @@ module IndirectionTable {
     // but it's kind of annoying. However, I think that it won't
     // be a big deal as long as most syncs are journaling syncs?
     // So I've moved back to this one which is slower but cleaner.
-    shared method {:timeLimitMultiplier 2} IndirectionTableToVal()  // HashMapToVal
+    shared method {:timeLimitMultiplier 3} IndirectionTableToVal()  // HashMapToVal
     returns (v : V, size: uint64)
     requires this.Inv()
     requires BC.WFCompleteIndirectionTable(this.I())

--- a/Impl/InsertModel.i.dfy
+++ b/Impl/InsertModel.i.dfy
@@ -61,7 +61,7 @@ module InsertModel {
     )
   }
 
-  lemma InsertKeyValueCorrect(s: BBC.Variables, key: Key, value: Value, replay: bool)
+  lemma {:timeLimitMultiplier 3} InsertKeyValueCorrect(s: BBC.Variables, key: Key, value: Value, replay: bool)
   requires InsertKeyValue.requires(s, key, value)
   requires WeightKey(key) + WeightMessage(Messages.Define(value)) +
       WeightBucketList(s.cache[BT.G.Root()].buckets) 

--- a/Impl/QueryImpl.i.dfy
+++ b/Impl/QueryImpl.i.dfy
@@ -44,7 +44,7 @@ module QueryImpl {
 
   // == query ==
 
-  method queryIterate(linear inout s: ImplVariables, key: Key, msg: Message, ref: BT.G.Reference, io: DiskIOHandler, counter: uint64, ghost lookup: seq<BT.G.ReadOp>)
+  method {:timeLimitMultiplier 3} queryIterate(linear inout s: ImplVariables, key: Key, msg: Message, ref: BT.G.Reference, io: DiskIOHandler, counter: uint64, ghost lookup: seq<BT.G.ReadOp>)
   returns (res: Option<Value>)
 
   requires old_s.Inv()

--- a/Impl/SplitModel.i.dfy
+++ b/Impl/SplitModel.i.dfy
@@ -266,7 +266,7 @@ module SplitModel {
     )
   }
 
-  lemma doSplitCorrect(s: BBC.Variables, parentref: BT.G.Reference, childref: BT.G.Reference, slot: int, refUpperBound: uint64)
+  lemma {:timeLimitMultiplier 3} doSplitCorrect(s: BBC.Variables, parentref: BT.G.Reference, childref: BT.G.Reference, slot: int, refUpperBound: uint64)
   requires doSplit.requires(s, parentref, childref, slot, refUpperBound)
   requires s.totalCacheSize() <= MaxCacheSize() - 2
   ensures var s' := doSplit(s, parentref, childref, slot, refUpperBound);

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ NONLINEAR_FLAGS = /noNLarith
 
 INDUCTION_FLAGS = /induction:1
 
-OTHER_PROVER_FLAGS = /rlimit:$(DEFAULT_RLIMIT)
+OTHER_PROVER_FLAGS =
 
 ### Adjust defaults for a couple of files
 # (It would be nice if we could do this in the source instead.)

--- a/lib/Base/Sequences.i.dfy
+++ b/lib/Base/Sequences.i.dfy
@@ -66,7 +66,7 @@ module Sequences {
     (forall i, j :: 0 <= i < |a| && 0 <= j < |a| && i != j ==> a[i] != a[j])
   }
 
-  lemma DisjointConcatenation<T>(a: seq<T>, b: seq<T>)
+  lemma {:timeLimitMultiplier 3} DisjointConcatenation<T>(a: seq<T>, b: seq<T>)
     requires NoDupes(a);
     requires NoDupes(b);
     requires multiset(a) !! multiset(b);
@@ -574,7 +574,7 @@ module Sequences {
     }
   }
 
-  lemma {:induction true} UnflattenIndexIsCorrect<A>(seqs: seq<seq<A>>, i: nat)
+  lemma {:induction true} {:timeLimitMultiplier 3} UnflattenIndexIsCorrect<A>(seqs: seq<seq<A>>, i: nat)
     requires i < FlattenLength(FlattenShape(seqs))
     ensures UnflattenIndex(FlattenShape(seqs), i).0 < |seqs|
     ensures UnflattenIndex(FlattenShape(seqs), i).1 < |seqs[UnflattenIndex(FlattenShape(seqs), i).0]|

--- a/lib/Buckets/PackedStringArray.i.dfy
+++ b/lib/Buckets/PackedStringArray.i.dfy
@@ -122,7 +122,7 @@ module PackedStringArray {
     4 + 4 * |psa.offsets| as uint64 + |psa.data| as uint64
   }
 
-  method CheckIsSorted(s: seq<uint32>) returns (b: bool)
+  method {:timeLimitMultiplier 3} CheckIsSorted(s: seq<uint32>) returns (b: bool)
   requires |s| < 0x1_0000_0000_0000_0000
   ensures b == Uint32_Order.IsSorted(s)
   {
@@ -520,7 +520,7 @@ module PackedStringArray {
     result := hi - 1;
   }
 
-  method BinarySearchIndexOfFirstKeyGtePivot(psa: Psa, key: UpperLexOrder.Element)
+  method {:timeLimitMultiplier 3} BinarySearchIndexOfFirstKeyGtePivot(psa: Psa, key: UpperLexOrder.Element)
   returns (idx: uint64)
   requires WF(psa)
   ensures idx as int

--- a/lib/DataStructures/LinearDList.i.dfy
+++ b/lib/DataStructures/LinearDList.i.dfy
@@ -238,7 +238,7 @@ module DList {
       inout ghost self.g := g';
     }
 
-    linear inout method{:timeLimitMultiplier 3} InsertAfter(p:uint64, a:A) returns (p':uint64)
+    linear inout method {:timeLimitMultiplier 3} InsertAfter(p:uint64, a:A) returns (p':uint64)
       requires old_self.Inv()
       requires old_self.MaybePtr(p)
       ensures self.Inv()
@@ -276,7 +276,7 @@ module DList {
       inout self.freeStack := freeNode.next;
     }
 
-    linear inout method{:timeLimitMultiplier 3} InsertBefore(p:uint64, a:A) returns(p':uint64)
+    linear inout method {:timeLimitMultiplier 3} InsertBefore(p:uint64, a:A) returns(p':uint64)
       requires old_self.Inv()
       requires old_self.MaybePtr(p)
       ensures self.Inv()

--- a/lib/DataStructures/LinearMutableMap.i.dfy
+++ b/lib/DataStructures/LinearMutableMap.i.dfy
@@ -132,7 +132,7 @@ module LinearMutableMap {
       getEmptyWitness(self, i+1)
   }
 
-  method {:timeLimitMultiplier 2} Probe<V>(shared self: FixedSizeLinearHashMap<V>, key: uint64)
+  method {:timeLimitMultiplier 3} Probe<V>(shared self: FixedSizeLinearHashMap<V>, key: uint64)
   returns (slotIdx: uint64, ghost startSlotIdx: uint64, ghost skips: uint64)
   requires FixedSizeInv(self)
   requires self.count as int < |self.storage|
@@ -620,7 +620,7 @@ module LinearMutableMap {
     assert EntryInSlotMatchesContents(self.underlying.storage, Slot(i as nat), self.underlying.contents); // trigger
   }
 
-  method Realloc<V>(linear inout self: LinearHashMap<V>)
+  method {:timeLimitMultiplier 3} Realloc<V>(linear inout self: LinearHashMap<V>)
     requires Inv(old_self)
     requires old_self.count as nat < 0x1_0000_0000_0000_0000 / 8
     ensures Inv(self)

--- a/lib/DataStructures/LinearMutableMap.i.dfy
+++ b/lib/DataStructures/LinearMutableMap.i.dfy
@@ -132,7 +132,7 @@ module LinearMutableMap {
       getEmptyWitness(self, i+1)
   }
 
-  method Probe<V>(shared self: FixedSizeLinearHashMap<V>, key: uint64)
+  method {:timeLimitMultiplier 2} Probe<V>(shared self: FixedSizeLinearHashMap<V>, key: uint64)
   returns (slotIdx: uint64, ghost startSlotIdx: uint64, ghost skips: uint64)
   requires FixedSizeInv(self)
   requires self.count as int < |self.storage|

--- a/tools/checkout-dafny-commit.sh
+++ b/tools/checkout-dafny-commit.sh
@@ -23,7 +23,7 @@ set -e
 set -x
 
 # currently set to 'betr' branch
-commit=2c810aa9cfa1ff413a7eb34730e71b722e6443d7
+commit=f6a0d73385d62
 if [ $1 ]; then
    commit=$1
 fi


### PR DESCRIPTION
resolved some of the rlimit issues by using multiplier, the following is my local build result:
```
verification error:
  lib/DataStructures/LinearContentMutableMap.i.dfy
  BlockCacheSystem/JournalInterval.i.dfy
exceeded rlimit:
  ByteBlockCacheSystem/InterpretationDisk.i.dfy
  BlockCacheSystem/BlockJournalCache.i.dfy
  Impl/FlushPolicyModel.i.dfy
  Impl/IOImpl.i.dfy
  lib/Buckets/LKMBPKVOps.i.dfy
  Impl/GrowImpl.i.dfy
  PivotBetree/StatesViewPivotBetree_Refines_StatesViewMap.i.dfy
  Impl/SplitModel.i.dfy
  lib/Buckets/PackedKV.i.dfy
  Impl/SyncImpl.i.dfy
  Impl/MarshallingImpl.i.dfy
  Versions/CompositeView_Refines_TSJMap.i.dfy
  Betree/Graph.i.dfy
  Impl/EvictImpl.i.dfy
  Impl/DeallocImpl.i.dfy
  lib/Checksums/CRC32CArrayImpl.i.dfy
```